### PR TITLE
Improved read from the InputStream. Or use (org.apache.commons.io.IOUtil...

### DIFF
--- a/oxalis-commons/src/main/java/eu/peppol/security/StatisticsKeyTool.java
+++ b/oxalis-commons/src/main/java/eu/peppol/security/StatisticsKeyTool.java
@@ -193,27 +193,24 @@ public class StatisticsKeyTool {
     }
 
     private byte[] loadBytesFrom(InputStream inputStream) {
-        // Dare not use available() here, assume encoded key will have a maximum length
-        byte[] bytes = new byte[MAX_LENGTH_OF_ENCODED_KEY];
 
-        int readBytes = 0;
-        try {
-            readBytes = inputStream.read(bytes);
-        } catch (IOException e) {
-            throw new IllegalStateException("I/O error during reading " + e, e);
-        }
-        if (readBytes == MAX_LENGTH_OF_ENCODED_KEY) {
-            throw new IllegalStateException("Wow! The encoded key is longer than " + MAX_LENGTH_OF_ENCODED_KEY + " bytes");
-        }
+		ByteArrayOutputStream buffer = new ByteArrayOutputStream();
 
-        // Transforms the byte array into its exact length, making handling easier.
-        byte[] result = new byte[readBytes];
-        for (int i = 0; i < readBytes; i++) {
-            result[i] = bytes[i];
-        }
-        return result;
-    }
+		int nRead;
+		byte[] data = new byte[MAX_LENGTH_OF_ENCODED_KEY];
 
+		try {
+			while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+				buffer.write(data, 0, nRead);
+			}
+
+			buffer.flush();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+		return buffer.toByteArray();
+
+	}
 
     private KeyFactory createKeyFactory() {
         try {


### PR DESCRIPTION
...s.toByteArray())

To prevent the following exception on oxalis-statistics-public.key loading

java.security.spec.InvalidKeySpecException: java.security.InvalidKeyException: IOException: Detect premature EOF
    sun.security.rsa.RSAKeyFactory.engineGeneratePublic(RSAKeyFactory.java:188)

java.security.KeyFactory.generatePublic(KeyFactory.java:304)
    eu.peppol.security.StatisticsKeyTool.publicKeyFromBytes(StatisticsKeyTool.java:164)
