### PR TITLE
Added proxy handling (standard JRE proxy selector)

### DIFF
--- a/oxalis-outbound/src/main/java/eu/peppol/outbound/transmission/As2MessageSender.java
+++ b/oxalis-outbound/src/main/java/eu/peppol/outbound/transmission/As2MessageSender.java
@@ -25,6 +25,7 @@ import org.apache.http.entity.ByteArrayEntity;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.SystemDefaultRoutePlanner;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,6 +41,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ProxySelector;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
 import java.util.Date;
@@ -292,9 +294,10 @@ class As2MessageSender implements MessageSender {
         X509HostnameVerifier hostnameVerifier = new AllowAllHostnameVerifier();
 
         SSLConnectionSocketFactory sslsf = new SSLConnectionSocketFactory(sslcontext, SSLConnectionSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
-
+        SystemDefaultRoutePlanner routePlanner = new SystemDefaultRoutePlanner(ProxySelector.getDefault());
         CloseableHttpClient httpclient = HttpClients.custom()
                 .setSSLSocketFactory(sslsf)
+                .setRoutePlanner(routePlanner)
                 .build();
 
         Registry<ConnectionSocketFactory> socketFactoryRegistry = RegistryBuilder.<ConnectionSocketFactory>create()


### PR DESCRIPTION
By default HttpClient doesn't use standard proxy setting, so they need to be registered.
