### PR TITLE
add properties getter to GlobalConfiguration

### DIFF
--- a/oxalis-commons/src/main/java/eu/peppol/util/GlobalConfiguration.java
+++ b/oxalis-commons/src/main/java/eu/peppol/util/GlobalConfiguration.java
@@ -126,6 +126,10 @@ public enum GlobalConfiguration {
         }
     }
 
+    public Properties getProperties() {
+        return properties;
+    }
+
     public String getJdbcDriverClassName() {
         return JDBC_DRIVER_CLASS.getValue(properties);
     }


### PR DESCRIPTION
I've added a `properties` getter to GlobalConfiguration to allow me to easily store custom configurations into Oxalis global configuration. With this getter, now I can do:

```
globalConfiguration.getProperties().getProperty('ingent.inbound.message.backup.store');
```

I'm not used to java, so maybe there's a better way to do this...
