### PR TITLE
Make HttpClient ValidateAfterInactivity and TimeToLive configurable

### DIFF
--- a/doc/configuration.adoc
+++ b/doc/configuration.adoc
@@ -220,6 +220,8 @@ Oxalis uses a shared connection pool of keep-alive connections to speed up trans
 ----
 oxalis.http.pool.max_route = 2
 oxalis.http.pool.total = 20
+oxalis.http.pool.validate_after_inactivity = 1000
+oxalis.http.pool.time_to_live = 30
 ----
 
 === Proxy [[config-http-proxy]]

--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/ApacheHttpModule.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/ApacheHttpModule.java
@@ -34,6 +34,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * @author erlend
  * @since 4.0.0
@@ -50,9 +52,10 @@ public class ApacheHttpModule extends OxalisModule {
     @Provides
     @Singleton
     protected PoolingHttpClientConnectionManager getPoolingHttpClientConnectionManager(Settings<HttpConf> settings) {
-        PoolingHttpClientConnectionManager httpClientConnectionManager = new PoolingHttpClientConnectionManager();
+        PoolingHttpClientConnectionManager httpClientConnectionManager = new PoolingHttpClientConnectionManager(settings.getInt(HttpConf.POOL_TIME_TO_LIVE), TimeUnit.SECONDS);
         httpClientConnectionManager.setDefaultMaxPerRoute(settings.getInt(HttpConf.POOL_MAX_ROUTE));
         httpClientConnectionManager.setMaxTotal(settings.getInt(HttpConf.POOL_TOTAL));
+        httpClientConnectionManager.setValidateAfterInactivity(settings.getInt(HttpConf.POOL_VALIDATE_AFTER_INACTIVITY));
 
         return httpClientConnectionManager;
     }

--- a/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/HttpConf.java
+++ b/oxalis-commons/src/main/java/no/difi/oxalis/commons/http/HttpConf.java
@@ -41,6 +41,14 @@ public enum HttpConf {
     @DefaultValue("2")
     POOL_MAX_ROUTE,
 
+    @Path("oxalis.http.pool.validate_after_inactivity")
+    @DefaultValue("1000")
+    POOL_VALIDATE_AFTER_INACTIVITY,
+
+    @Path("oxalis.http.pool.time_to_live")
+    @DefaultValue("30")
+    POOL_TIME_TO_LIVE,
+
     @Path("oxalis.http.timeout.connect")
     @DefaultValue("0")
     TIMEOUT_CONNECT,

--- a/oxalis-extension/oxalis-as2/src/test/resources/reference.conf
+++ b/oxalis-extension/oxalis-as2/src/test/resources/reference.conf
@@ -6,3 +6,5 @@ oxalis.persister.payload = noop
 oxalis.persister.receipt = noop
 
 oxalis.http.pool.max_route = 10
+oxalis.http.pool.validate_after_inactivity = 1000
+oxalis.http.pool.time_to_live = 30


### PR DESCRIPTION
This solves problem with networks that cuts inactive connections at arbitrary timeout causing SocketTimeoutException and "Read timed out"