### PR TITLE
Provide default method for Settings toLogSafeString

### DIFF
--- a/oxalis-api/src/main/java/network/oxalis/api/settings/Settings.java
+++ b/oxalis-api/src/main/java/network/oxalis/api/settings/Settings.java
@@ -49,5 +49,7 @@ public interface Settings<T> {
         return path.resolve(value);
     }
 
-    String toLogSafeString(T key);
+    default String toLogSafeString(T key) {
+        return getString(key);
+    }
 }


### PR DESCRIPTION
Such that existing implementations of the interface don't require change.