### PR TITLE
ERST: Tomcat relative oxalis home

### DIFF
--- a/oxalis-commons/src/main/java/network/oxalis/commons/filesystem/detector/RelativePropertyHomeDetector.java
+++ b/oxalis-commons/src/main/java/network/oxalis/commons/filesystem/detector/RelativePropertyHomeDetector.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2010-2018 Norwegian Agency for Public Management and eGovernment (Difi)
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they
+ * will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+ *
+ * Unless required by applicable law or agreed to in
+ * writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package network.oxalis.commons.filesystem.detector;
+
+import lombok.extern.slf4j.Slf4j;
+import network.oxalis.api.filesystem.HomeDetector;
+import network.oxalis.api.util.Sort;
+import org.kohsuke.MetaInfServices;
+
+import java.io.File;
+
+/**
+ * @author ERST
+ */
+@Slf4j
+@Sort(2500)
+@MetaInfServices
+public class RelativePropertyHomeDetector implements HomeDetector {
+
+    protected static final String VARIABLE = "RELATIVE_OXALIS_HOME";
+
+    @Override
+    public File detect() {
+        String value = System.getProperty(VARIABLE);
+        if (value == null || value.isEmpty())
+            return null;
+
+        if(value.startsWith("/")){
+            value = value.substring(1);
+        }
+
+        String catalinaBase = System.getProperty("catalina.base");
+
+        log.info("Using Oxalis folder specified as Java System Property '-D {}' with value '{}/{}'.",
+                VARIABLE, catalinaBase, value);
+        return new File(catalinaBase, value);
+    }
+}
+

--- a/oxalis-commons/src/test/java/network/oxalis/commons/filesystem/detector/RelativePropertyHomeDetectorTest.java
+++ b/oxalis-commons/src/test/java/network/oxalis/commons/filesystem/detector/RelativePropertyHomeDetectorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2010-2018 Norwegian Agency for Public Management and eGovernment (Difi)
+ *
+ * Licensed under the EUPL, Version 1.1 or – as soon they
+ * will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ *
+ * You may not use this work except in compliance with the Licence.
+ *
+ * You may obtain a copy of the Licence at:
+ *
+ * https://joinup.ec.europa.eu/community/eupl/og_page/eupl
+ *
+ * Unless required by applicable law or agreed to in
+ * writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied.
+ * See the Licence for the specific language governing
+ * permissions and limitations under the Licence.
+ */
+
+package network.oxalis.commons.filesystem.detector;
+
+import network.oxalis.api.filesystem.HomeDetector;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.io.File;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author ERST
+ */
+public class RelativePropertyHomeDetectorTest {
+
+    private HomeDetector homeDetector = new RelativePropertyHomeDetector();
+
+    @BeforeClass
+    public void setup(){
+        System.setProperty("catalina.base", "/catalina");
+    }
+
+    @AfterClass
+    public void cleanup(){
+        System.clearProperty("catalina.base");
+    }
+
+    @Test
+    public void testFromJavaSystemProperty() {
+        String path = new File("/catalina/some/system/path2").getAbsolutePath();
+        String backup = System.getProperty(RelativePropertyHomeDetector.VARIABLE);
+
+        try {
+            System.clearProperty(RelativePropertyHomeDetector.VARIABLE);
+            File oxalis_home = homeDetector.detect();
+            assertNull(oxalis_home);
+
+            System.setProperty(RelativePropertyHomeDetector.VARIABLE, "");
+            oxalis_home = homeDetector.detect();
+            assertNull(oxalis_home);
+
+            System.setProperty(RelativePropertyHomeDetector.VARIABLE, "some/system/path2");
+            oxalis_home = homeDetector.detect();
+            assertEquals(oxalis_home.getAbsolutePath(), path);
+
+            System.setProperty(RelativePropertyHomeDetector.VARIABLE, "/some/system/path2");
+            oxalis_home = homeDetector.detect();
+            assertEquals(oxalis_home.getAbsolutePath(), path);
+        } finally {
+            if (backup == null) backup = ""; // prevent null pointer exception
+            System.setProperty(RelativePropertyHomeDetector.VARIABLE, backup);
+        }
+    }
+}


### PR DESCRIPTION
## Pull Request Description
Erhvervsstyrelsen (ERST) has implemented a Tomcat relative property home detector. It takes a property RELATIVE_OXALIS_HOME and detects that path relative to the Tomcat catalina.base property. This is very useful for us as we put the oxalis home folder in the same place in the Tomcat folder but the absolute path to the Tomcat folder is not consistent on differnet environments or on developers computers.

See change here:
https://rep.erst.dk/git/openebusiness/nemhandeledelivery/oxalis/-/blob/master/oxalis-commons/src/main/java/dk/erst/oxalis/commons/filesystem/detector/RelativePropertyHomeDetector.java

## Type of Pull Request

- [X] New feature/Enhancement - non-breaking change which adds functionality
- [ ] Bug fix 
- [ ] Breaking change (Require Major version change?)

## Type of Change

- [ ] OpenPeppol AS2/AS4 specification
- [ ] OpenPeppol Spring/Fall release 
- [X] Oxalis software change or enhancement
- [ ] CEF change

## Pull Request Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas. But did not added unnecessary annotation/comment say @author name etc
- [X] I have checked my code for variable and method name and corrected grammar/spelling mistakes if any
- [X] I have made corresponding changes to the documentation where needed
- [X] My changes generate no new/additional warnings
- [X] My change is not breaking or creating conflict with associated dependencies 
- [X] I have performed a self-review of my own code
- [X] I ran `mvn clean install` before commit and all tests run successfully 
- [X] I conducted basic QA to assure all features are working fine
- [X] My pull request generate no conflicts with `master` branch
- [ ] I requested code review from other team members
